### PR TITLE
Create foldx jobs

### DIFF
--- a/pyse/create_foldx_jobs.py
+++ b/pyse/create_foldx_jobs.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# # -*- coding: utf-8 -*-
+
+"""
+Create Foldx Jobs
+
+This tool creates foldx job directories to be parsed and processed by
+scan_foldx_jobs. It takes as input a source pdb file, which is parsed
+to generate all possible combinations of mutations based on the ATOM
+lines read from the file.
+
+The jobs created by this tool are used to run the foldx BuildModel
+command.  The job directories contain 2 data elements:
+  1. list.txt - the name of the source pdb file. This is usually a repaired
+                pdb file.
+  2. individual_list.txt - wild type amino (starting amino letter), the chain
+                           (A, B, C, ...), the residue number (site position),
+                           and the mutant residue (target mutation).
+
+See the BuildModel command in the foldx documentation for more information.
+
+We generate a separate job directory for every site position and
+target mutation, grouped by the chains with matching wild types in
+that position. For example, if site 2 of a given pdb has the following
+wild types and chains:
+  A. LYS (K)
+  B. LYS (K)
+  C. GLU (E)
+  D. HIS (H)
+  E. GLU (E)
+
+This will produce 3 sets: {A, B}, {C, E}, and {D}. Each set will produce a
+mutation against each target, including itself.
+
+The original version of this tool can be found in generate_buildmodel.py
+
+"""
+from __future__ import print_function
+
+import click
+import os
+import uuid
+
+from collections import defaultdict
+
+from pdb import parse_pdb
+from proteins import codes
+
+
+def makeJobDir(pdbfile, jobid, line, basedir='.'):
+    """Generate a job directory for a work item.
+    :param pdbfile: the name of the pdbfile that this work item is used with.
+    :param line: the mutation(s) that this work item should perform.
+    :returns: None.  Generates a folder and FoldX work files on disk. """
+    pdb_name = pdbfile
+    dir_name = "foldxbm-{}".format(jobid)
+    full_loc = os.path.join(basedir, protein_name, dir_name)
+    os.makedirs(full_loc)
+    with open(os.path.join(full_loc, 'individual_list.txt'), 'wb') as il:
+        il.write(os.path.basename(pdbfile) + '\n')
+    with open(os.path.join(full_loc, 'list.txt'), 'wb') as l:
+        l.write(line + '\n')
+
+def generate_chaingroups(pdbfn):
+    """This parses the pdb then generates the following structure for
+    generating build job folders:
+      site: {wildtype: [groups]}
+    """
+    chaingroups = defaultdict(defaultdict(set))
+    with open(pdbfn, 'r') as pdbfile:
+        for pdbentry in parse_pdb(pdbfile):
+            wildtype = pdbentry['remnant']
+            chain = pdbentry['chain']
+            site = pdbentry['position']
+            chaingroups[site][wildtype].add(chain)
+    return chaingroups
+
+@click.command()
+@click.option('--outdir', '-o', default='.',
+              help='The output job directory')
+@click.option('--protein', '-p', default=None,
+              help=('The name of the protein (jobs are put in '
+                    'jobdir/proteinname/jobname)'))
+@click.argument('pdbfile')
+def main(outdir, protein, pdbfile):
+    outdir = os.path.join(outdir, protein)
+    print('Reading {} and putting job directories in {}'.format(pdbfile,
+                                                                outdir))
+    chaingroups = generate_chaingroups(pdbfile)
+    for site, chaingroup in chaingroups.items():
+        for wildtype, chains in chaingroup:
+            wtamino = codes[wildtype]
+            for mut in codes.values():
+                mutlist = ','.join(['{}{}{}{}'.format(wtamino, chain, site, mut)
+                                    for chain in chains]) + ';'
+                jobid = '{}-{}-{}'.format(site, wtamino, mut)
+                makeJobDir(pdbfile, jobid, mutlist, outdir)

--- a/pyse/generate_buildmodel.py
+++ b/pyse/generate_buildmodel.py
@@ -35,14 +35,14 @@ def parse_seqfile(filename):
     return chain_aminos
 
 
-def makeJobDir(protein_name, line):
+def makeJobDir(protein_name, line, basedir='.'):
     """Generate a job directory for a work item.
     :param protein_name: the name of the protein that this work item is used with.
     :param line: the mutation(s) that this work item should perform. 
     :returns: None.  Generates a folder and FoldX work files on disk. """
     pdb_name = pdbs[protein_name]
     dir_name = "foldxbm-" + str(uuid.uuid4())
-    full_loc = protein_name + "/" + dir_name
+    full_loc = os.path.join(basedir, protein_name, dir_name)
     os.makedirs(full_loc)
     f = open(full_loc + '/individual_list.txt', 'w+')
     f2 = open(full_loc + '/list.txt', 'w+')

--- a/pyse/parse_foldx_jobs.py
+++ b/pyse/parse_foldx_jobs.py
@@ -26,6 +26,8 @@ import sys
 from collections import defaultdict
 from multiprocessing import Pool, cpu_count
 
+from pdb import parse_pdb
+
 # Define and error printing function in lieu of logging api
 eprint = functools.partial(print, file=sys.stderr, flush=True)
 
@@ -121,29 +123,6 @@ def parse_raw_buildmodel(pdb, rawmodel):
     assert len(energies) == len(wt_energies)
 
     return energies, wt_energies
-
-def parse_pdb(pdb):
-    """ Read the x,y,z positions for each atom in a PDB file """
-    positions = []
-
-    def stripstr(v):
-        return str(v).strip()
-    for line in pdb:
-        if not line.startswith('ATOM'):
-            continue
-        # these are specified as inclusive ranges of 1-based
-        # indexes to match the PDB spec
-        fieldspec = [
-            ('atom', 13, 16, stripstr),
-            ('remnant', 18, 20, stripstr),
-            ('chain', 22, 22, stripstr),
-            ('position', 23, 26, int),
-            ('x', 31, 38, float),
-            ('y', 39, 46, float),
-            ('z', 47, 54, float),
-        ]
-        positions.append({f[0]: f[3](line[f[1] - 1:f[2]]) for f in fieldspec})
-    return positions
 
 def calculate_energy_deltas(energies, wt_energies):
     """Sum the columns in the energies and wt_energies lists and

--- a/pyse/parse_foldx_jobs.py
+++ b/pyse/parse_foldx_jobs.py
@@ -26,7 +26,7 @@ import sys
 from collections import defaultdict
 from multiprocessing import Pool, cpu_count
 
-from pdb import parse_pdb
+from pyse.pdb import parse_pdb
 
 # Define and error printing function in lieu of logging api
 eprint = functools.partial(print, file=sys.stderr, flush=True)

--- a/pyse/pdb.py
+++ b/pyse/pdb.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# # -*- coding: utf-8 -*-
+
+"""
+Functions for processing pdb files
+"""
+
+def parse_pdb(pdb):
+    """ Read the x,y,z positions for each atom in a PDB file """
+    positions = []
+
+    def stripstr(v):
+        return str(v).strip()
+    for line in pdb:
+        if not line.startswith('ATOM'):
+            continue
+        # these are specified as inclusive ranges of 1-based
+        # indexes to match the PDB spec
+        fieldspec = [
+            ('atom', 13, 16, stripstr),
+            ('remnant', 18, 20, stripstr),
+            ('chain', 22, 22, stripstr),
+            ('position', 23, 26, int),
+            ('x', 31, 38, float),
+            ('y', 39, 46, float),
+            ('z', 47, 54, float),
+        ]
+        positions.append({f[0]: f[3](line[f[1] - 1:f[2]]) for f in fieldspec})
+    return positions

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
        'console_scripts': [
            'compute_shannon_entropy = pyse.compute_shannon_entropy:main',
            'pfj = pyse.parse_foldx_jobs:main'
+           'cfj = pyse.create_foldx_jobs:main'
        ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     entry_points={
        'console_scripts': [
            'compute_shannon_entropy = pyse.compute_shannon_entropy:main',
-           'pfj = pyse.parse_foldx_jobs:main'
+           'pfj = pyse.parse_foldx_jobs:main',
            'cfj = pyse.create_foldx_jobs:main'
        ]
     }


### PR DESCRIPTION
Add the create_foldx_jobs tool. This tool is a replacement for generate_buildmodel that generates foldx jobs based only on the input pdb instead of parsing the foldx sequence files. It also generates mutations for all wild type chain groups instead of the reference group.